### PR TITLE
fix: #193 挂件列表发布文档选择子文档时读取的是当前文档的信息

### DIFF
--- a/src/components/blog/themes/default/DefaultPublish.vue
+++ b/src/components/blog/themes/default/DefaultPublish.vue
@@ -13,9 +13,9 @@
 </template>
 
 <script lang="ts" setup>
-import {ArrowLeft} from '@element-plus/icons-vue'
+import {ArrowLeft} from "@element-plus/icons-vue";
 import PublishService from "../../../publish/PublishService.vue";
-import {Post} from "../../../../utils/common/post";
+import {Post} from "~/utils/common/post";
 
 const props = defineProps({
   publishData: {

--- a/src/components/publish/tab/PlantformMain.vue
+++ b/src/components/publish/tab/PlantformMain.vue
@@ -42,11 +42,10 @@
 
 <script lang="ts" setup>
 import {onMounted, reactive, ref, watch} from "vue";
-import {getBooleanConf, setBooleanConf} from "../../../utils/config";
-import SWITCH_CONSTANTS from "../../../utils/constants/switchConstants";
-import logUtil from "../../../utils/logUtil";
-import {DynamicConfig, getDynamicJsonCfg} from "../../../utils/dynamicConfig";
-import {useTabCount} from "../../../composables/tabCountCom";
+import {getBooleanConf} from "~/utils/config";
+import logUtil from "~/utils/logUtil";
+import {DynamicConfig, getDynamicJsonCfg} from "~/utils/dynamicConfig";
+import {useTabCount} from "~/composables/tabCountCom";
 
 // use
 const {

--- a/src/utils/platform/siyuan/siyuanUtil.ts
+++ b/src/utils/platform/siyuan/siyuanUtil.ts
@@ -109,8 +109,8 @@ async function getSiyuanPageId(force?: boolean) {
 /**
  * 获取页面ID，如果不是挂件模式，可以自己提供一个页面ID
  * 优先级
- * 1、挂件ID
- * 2、自己显式的传递一个ID
+ * 1、自己显式的传递一个ID
+ * 2、挂件ID
  * 3、浏览器参数id=传递的ID
  * 4、VITE_SIYUAN_DEV_PAGE_ID写死的测试ID
  * @param force 是否强制刷新
@@ -119,23 +119,25 @@ async function getSiyuanPageId(force?: boolean) {
 export async function getPageId(force?: boolean, pageId?: string) {
     let syPageId
 
-    // 先兼容挂件
-    const widgetResult = getWidgetId()
-    if (widgetResult.isInSiyuan) {
-        // 尝试读取挂件的ID
-        syPageId = await getSiyuanPageId(force)
-    }
-
-    //如果其他地方想使用，也可以显式的传入一个页面ID
-    // logUtil.logInfo("pageId=>", pageId)
-    if (!syPageId) {
+    // 1、显式传递的ID优先处理
+    if (pageId) {
         logUtil.logInfo("显示指定pageId=>", pageId)
         syPageId = pageId
     }
 
+
+    // 2、兼容挂件
+    if (!syPageId) {
+        const widgetResult = getWidgetId()
+        if (widgetResult.isInSiyuan) {
+            // 尝试读取挂件的ID
+            syPageId = await getSiyuanPageId(force)
+        }
+    }
+
     // logUtil.logInfo("syPageId=>", syPageId)
     if (!syPageId) {
-        //  开发模式模拟传递一个ID
+        //  3、开发模式模拟传递一个ID
         if (!pageId) {
             const testPageId = getEnv("VITE_SIYUAN_DEV_PAGE_ID")
             if (!testPageId && inBrowser()) {


### PR DESCRIPTION
fix: #193 挂件列表发布文档选择子文档时读取的是当前文档的信息